### PR TITLE
unicoder

### DIFF
--- a/core/stack.py
+++ b/core/stack.py
@@ -12,6 +12,7 @@ from helpers import functions
 from view_generators.view_mapper import ViewMapper
 from view_generators.view_maps import QuantipyViews
 from quantipy.core.tools.dp.spss.reader import parse_sav_file
+from quantipy.core.tools.dp.io import unicoder
 
 import itertools
 from collections import defaultdict, OrderedDict
@@ -657,7 +658,7 @@ class Stack(defaultdict):
                                 aggfunc='count')
         return description
 
-    def save(self, path_stack, compression="gzip"):
+    def save(self, path_stack, compression="gzip", decode_str=True):
         """
         Save Stack instance to .stack file.
 
@@ -669,6 +670,9 @@ class Stack(defaultdict):
         compression : {'gzip', 'lzma'}, default 'gzip'
             The intended compression type. 'lzma' offers high compression but
             can be very slow.
+        decode_str : bool, default=True
+            If True the unicoder function will be used to decode all str
+            objects found anywhere in the meta document/s.
         
         Returns
         -------
@@ -682,6 +686,13 @@ class Stack(defaultdict):
                 "stack.save(path_stack='./output/MyStack.stack'). Your call looks like this: "
                 "stack.save(path_stack='%s', ...)" % (path_stack)
             )
+
+        # Make sure there are no str objects in any meta documents. If
+        # there are any non-ASCII characters will be encoded 
+        # incorrectly and lead to UnicodeDecodeErrors in Jupyter.
+        if decode_str:
+            for dk in self.keys():
+                self[dk].meta = unicoder(self[dk].meta)
 
         if compression is None:
             f = open(path_stack, 'wb')

--- a/core/stack.py
+++ b/core/stack.py
@@ -658,7 +658,7 @@ class Stack(defaultdict):
                                 aggfunc='count')
         return description
 
-    def save(self, path_stack, compression="gzip", decode_str=True):
+    def save(self, path_stack, compression="gzip", decode_str=False):
         """
         Save Stack instance to .stack file.
 

--- a/core/tools/dp/io.py
+++ b/core/tools/dp/io.py
@@ -22,6 +22,44 @@ from quantipy.core.tools.dp.spss.reader import parse_sav_file
 from quantipy.core.tools.dp.spss.writer import save_sav
 from quantipy.core.tools.dp.ascribe.reader import quantipy_from_ascribe
 
+def unicoder(obj):
+    """
+    Decodes all the text (keys and strings) in obj.
+    
+    Recursively mines obj for any str objects, whether keys
+    or values, converting any str objects to unicode.
+    
+    Parameters
+    ----------
+    obj : object
+        The object to be mined.
+        
+    Returns
+    -------
+    obj : object
+        The recursively decoded object. 
+    """
+    
+    if isinstance(obj, list):
+        obj = [
+            unicoder(item)
+            for item in obj
+        ]
+    if isinstance(obj, tuple):
+        obj = tuple([
+            unicoder(item)
+            for item in obj
+        ])
+    elif isinstance(obj, (dict)):
+        obj = {
+            key: unicoder(value)
+            for key, value in obj.iteritems()
+        }
+    elif isinstance(obj, str):
+        obj = unicode(obj, 'utf-8')
+    
+    return obj
+
 def load_json(path_json, hook=OrderedDict):
     ''' Returns a python object from the json file located at path_json
     '''
@@ -44,6 +82,8 @@ def load_csv(path_csv):
     return pd.DataFrame.from_csv(path_csv)
 
 def save_json(obj, path_json):
+
+    obj = unicoder(obj)
 
     def represent(obj):
         if isinstance(obj, np.generic):

--- a/core/tools/dp/io.py
+++ b/core/tools/dp/io.py
@@ -81,9 +81,10 @@ def load_csv(path_csv):
     
     return pd.DataFrame.from_csv(path_csv)
 
-def save_json(obj, path_json):
+def save_json(obj, path_json, decode_str=False, decoder='UTF-8'):
 
-    obj = unicoder(obj)
+    if decode_str:
+        obj = unicoder(obj, decoder)
 
     def represent(obj):
         if isinstance(obj, np.generic):

--- a/core/tools/dp/io.py
+++ b/core/tools/dp/io.py
@@ -8,6 +8,8 @@ import math
 import re, string
 import sqlite3
 
+from ftfy import fix_text
+
 from collections import OrderedDict
 from quantipy.core.helpers.constants import DTYPE_MAP
 from quantipy.core.helpers.constants import MAPPED_PATTERN
@@ -26,8 +28,9 @@ def unicoder(obj, decoder='UTF-8'):
     """
     Decodes all the text (keys and strings) in obj.
     
-    Recursively mines obj for any str objects, whether keys
-    or values, converting any str objects to unicode.
+    Recursively mines obj for any str objects, whether keys or values,
+    converting any str objects to unicode and then correcting the 
+    unicode (which may have been decoded incorrectly) using ftfy.
     
     Parameters
     ----------
@@ -56,7 +59,7 @@ def unicoder(obj, decoder='UTF-8'):
             for key, value in obj.iteritems()
         }
     elif isinstance(obj, str):
-        obj = unicode(obj, decoder)
+        obj = fix_text(unicode(obj, decoder))
     
     return obj
 

--- a/core/tools/dp/io.py
+++ b/core/tools/dp/io.py
@@ -22,7 +22,7 @@ from quantipy.core.tools.dp.spss.reader import parse_sav_file
 from quantipy.core.tools.dp.spss.writer import save_sav
 from quantipy.core.tools.dp.ascribe.reader import quantipy_from_ascribe
 
-def unicoder(obj):
+def unicoder(obj, decoder='UTF-8'):
     """
     Decodes all the text (keys and strings) in obj.
     
@@ -56,7 +56,7 @@ def unicoder(obj):
             for key, value in obj.iteritems()
         }
     elif isinstance(obj, str):
-        obj = unicode(obj, 'utf-8')
+        obj = unicode(obj, decoder)
     
     return obj
 


### PR DESCRIPTION
The following new meta was causing a UnicodeDecodeError in the ExcelPainter, because it results in a mixture of unicode and str objects throughout the document:

```python
meta['columns'][target]['values'].extend(
    [
        {'value': 901, 'text': {'en-GB': 'Under £20k (Income group 1'}},
        {'value': 902, 'text': {'en-GB': '£20,000 to £50,000 (Income group 2)'}},
        {'value': 903, 'text': {'en-GB': '£50,001 + (Income group 3)'}}
    ]
)
```

I've added the following function to ``quantipy.core.tools.dp.io.py``:

```python
def unicoder(obj):
    """
    Decodes all the text (keys and strings) in obj.
    
    Recursively mines obj for any str objects, whether keys
    or values, converting any str objects to unicode.
    
    Parameters
    ----------
    obj : object
        The object to be mined.
        
    Returns
    -------
    obj : object
        The recursively decoded object. 
    """
    
    if isinstance(obj, list):
        obj = [
            unicoder(item)
            for item in obj
        ]
    if isinstance(obj, tuple):
        obj = tuple([
            unicoder(item)
            for item in obj
        ])
    elif isinstance(obj, (dict)):
        obj = {
            key: unicoder(value)
            for key, value in obj.iteritems()
        }
    elif isinstance(obj, str):
        obj = unicode(obj, 'utf-8')
    
    return obj

```

This has become default behaviour in both ``quantipy.core.tools.dp.io.save_json()`` AND ``stack.save()``. The latter can be escaped by using ``stack.save(..., decode_str=False)``.

This is necessary to overcome the UnicodeDecodeError that would otherwise happen in a Jupyter Notebook when writing said labels with the ExcelPainter.