### PR TITLE
Bug fix for logic as list in get_logic_key()

### DIFF
--- a/core/tools/view/logic.py
+++ b/core/tools/view/logic.py
@@ -1345,7 +1345,8 @@ def get_logic_index(series, logic, data=None):
     """
 
     if isinstance(logic, list):
-        logic = (_has_any, logic)
+        logic = (_has_any, logic, False)
+        idx, vkey = resolve_logic(series, logic, data)
 
     if isinstance(logic, (tuple, dict)):
         idx, vkey = resolve_logic(series, logic, data)


### PR DESCRIPTION
Function does not crash and returns correct logic key when logic is a list. I have added False to the logic tuple to mimic has_any. idx and vkey are now assigned from resolve_logic().