### PR TITLE
An easier way to extract a dataframe from a stack or chain

### DIFF
--- a/core/tools/view/query.py
+++ b/core/tools/view/query.py
@@ -183,7 +183,7 @@ def get_num_stats_relation_from_fullname(fullname):
     '''
     return fullname.split('|',3)[2]
 
-def get_dataframe(obj, describe=None, loc=None, keys=None, show=False):
+def get_dataframe(obj, described=None, loc=None, keys=None, show=False):
     """
     Convenience function for extracting a single dataframe from a stack.
     
@@ -197,7 +197,7 @@ def get_dataframe(obj, describe=None, loc=None, keys=None, show=False):
     ----------
     obj : quantipy.Stack or quantipy.Chain
         The stack or chain from which the dataframe should be extracted.
-    describe : pandas.DataFrame, default=None
+    described : pandas.DataFrame, default=None
         If given, this will be used with loc to identify the string of
         targeted keys. This parameter is provided to reduce repeated
         calls to obj.describe() when this function is being used in a
@@ -223,8 +223,8 @@ def get_dataframe(obj, describe=None, loc=None, keys=None, show=False):
         raise ValueError (
             "You must provide a value for either loc or keys."
         )
-    if not describe is None:
-        if not isinstance(describe, pd.DataFrame):
+    if not described is None:
+        if not isinstance(described, pd.DataFrame):
             raise TypeError (
                 "The describe argument must be a pandas.DataFrame."
             )
@@ -240,7 +240,9 @@ def get_dataframe(obj, describe=None, loc=None, keys=None, show=False):
     
     if not loc is None:
         # Use loc to generate keys
-        keys = obj.describe().loc[loc]
+        if described is None:
+            described = obj.describe()
+        keys = described.loc[loc]
 
     # Split out pathway to the target dataframe
     dk = keys[0]

--- a/core/tools/view/query.py
+++ b/core/tools/view/query.py
@@ -206,7 +206,7 @@ def get_dataframe(obj, described=None, loc=None, keys=None, show=False):
         The .loc[] indexer that can be used on described or 
         obj.describe() to isolate the targeted dataframe.
     keys : list-like, default=None
-        A list of five yes (dk, fk, xk, yk, vk) that can be used on obj
+        A list of five keys (dk, fk, xk, yk, vk) that can be used on obj
         to isolate the targeted dataframe.
     show : bool, default=False
         If True, the keys used in the extraction will be printed to the

--- a/core/tools/view/query.py
+++ b/core/tools/view/query.py
@@ -228,10 +228,6 @@ def get_dataframe(obj, described=None, loc=None, keys=None, show=False):
             raise TypeError (
                 "The describe argument must be a pandas.DataFrame."
             )
-        if loc is None:
-            raise ValueError (
-                "When providing describe you must also provide loc."
-            )
     # Error handling for both loc and keys being provided
     if all([not arg is None for arg in [loc, keys]]):
         raise ValueError (

--- a/core/tools/view/query.py
+++ b/core/tools/view/query.py
@@ -203,8 +203,8 @@ def get_dataframe(obj, described=None, loc=None, keys=None, show=False):
         calls to obj.describe() when this function is being used in a
         loop.
     loc : int, default=None
-        The .loc[] indexer that can be used on obj.describe() to isolate
-        the targeted dataframe.
+        The .loc[] indexer that can be used on described or 
+        obj.describe() to isolate the targeted dataframe.
     keys : list-like, default=None
         A list of five yes (dk, fk, xk, yk, vk) that can be used on obj
         to isolate the targeted dataframe.


### PR DESCRIPTION
In the past we've had to do something like the following to see the result of any given view:

```python
dk = 'data key'
fk = 'filter key'
xk = 'x key'
yk = 'y key'
vk = 'view key'

df = stack[dk][fk][vk][xk][yk][vk].dataframe
```

This was not only verbose but also prone to a gotcha error when the final view key either didn't exist or the aggregation for it had failed. In these situations you would receive and ``AttributeError`` stating ``Stack instance has no attribute dataframe.``

Now we have the following function to both extract targeted dataframe much more easily and to manage checking for/reporting missing keys the user may be asking for.

I'll be adding comprehensive examples to the docs for this next week.

```python
def get_dataframe(obj, described=None, loc=None, keys=None, show=False):
    """
    Convenience function for extracting a single dataframe from a stack.
    
    This function either uses a string of keys sliced out of 
    obj.describe() or the result of same, or a string of keys provided
    by the user, to return a single, targeted dataframe from obj. 
    Optionally, the exact keys used in the extraction can be printed to
    the output window for verification.
    
    Parameters
    ----------
    obj : quantipy.Stack or quantipy.Chain
        The stack or chain from which the dataframe should be extracted.
    described : pandas.DataFrame, default=None
        If given, this will be used with loc to identify the string of
        targeted keys. This parameter is provided to reduce repeated
        calls to obj.describe() when this function is being used in a
        loop.
    loc : int, default=None
        The .loc[] indexer that can be used on described or 
        obj.describe() to isolate the targeted dataframe.
    keys : list-like, default=None
        A list of five yes (dk, fk, xk, yk, vk) that can be used on obj
        to isolate the targeted dataframe.
    show : bool, default=False
        If True, the keys used in the extraction will be printed to the
        output window.
        
    Returns
    -------
    df : pandas.DataFrame
        The targeted dataframe. 
    """
```

Import statement and wire-frame examples:

```python
from quantipy.core.tools.view.query import get_dataframe

print get_dataframe(stack, loc=15, show=True)

keys = stack.describe().loc[15]
print get_dataframe(stack, keys=keys, show=True)

described = stack.describe()
print get_dataframe(stack, described=described, loc=15, show=True)

print get_dataframe(stack, described=described, keys=keys, show=True)
```