### PR TITLE
Improving request_views(..., sig_levels) possible values.

### DIFF
--- a/core/tools/dp/query.py
+++ b/core/tools/dp/query.py
@@ -157,6 +157,8 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
         "high": ".01"
     }
 
+    if not isinstance(sig_levels, (list, tuple)):
+        sig_levels = [sig_levels]
     lvls = []
     for level in sig_levels:
         # Remove leading 0

--- a/core/tools/dp/query.py
+++ b/core/tools/dp/query.py
@@ -1,4 +1,5 @@
 import quantipy as qp
+import re
 
 def get_views(qp_structure):
     ''' Generator replacement for nested loops to return all view objects
@@ -85,7 +86,9 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
     mimic : str
         The mimic type to be targeted when finding coltests.
     sig_levels : list-like, default=[".05"]
-        The level/s of significance being requested, e.g. [".05", ".10"]
+        The level/s of significance being requested, e.g. [".05", ".1"]
+        or any of ["low", "mid", "high"] for [".10", ".05", ".01"] 
+        respectively.
 
     Returns
     -------
@@ -148,9 +151,28 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
     ps = ['x|frequency||y|%s|c%%' % (weight)]
     cps = cs[:] + ps [:]
     
+    levels_ref = {
+        "low": ".10",
+        "mid": ".05",
+        "high": ".01"
+    }
+
+    lvls = []
+    for level in sig_levels:
+        # Remove leading 0
+        if level[0]=='0': level = level[1:]
+        if level in levels_ref.keys():
+            lvls.append(levels_ref[level])
+        elif not re.match('\.[0-9]$', level) is None:
+            lvls.append('{}0'.format(level))
+        else:
+            lvls.append(level)
+    sig_levels = lvls
+
     # Column tests for main views
     if coltests:
         for level in sig_levels:
+
             # Main test views
             props_test_views = [
                 v for v in all_views 
@@ -191,6 +213,7 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
         if coltests:
             net_test_views = []
             for level in sig_levels:
+
                 if nets:
                     # Net test views
                     net_test_views.extend([
@@ -225,6 +248,7 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
             if descriptive=='mean' and coltests:
                 means_test_views = []
                 for level in sig_levels:
+
                     # Means test views
                     means_test_views.extend([
                         v for v in all_views 


### PR DESCRIPTION
Improved possible values for ``request_views(..., sig_levels)`` to include standard ``'low'``, ``'mid'``, ``'high'`` vernacular plus missing trailing zero (``'.1'``), or redundant leading zero (``'0.1'``).

When only requesting 1 level ``sig_levels`` can now also be given as a string instead of needing to be a string inside a list.

Examples:

```python
Input         Read as
---------------------
".10"   -->   ".10"
".05"   -->   ".05"
".01"   -->   ".01"
"low"   -->   ".10"
"mid"   -->   ".05"
"high"  -->   ".01"
".1"    -->   ".10"
"0.1"   -->   ".10"
".95"   -->   ".95"
"0.55"  -->   ".55"
```

This resolves #68 