### PR TITLE
Fixed column names during recode de-duplication, which were appearing…

### DIFF
--- a/core/tools/dp/prep.py
+++ b/core/tools/dp/prep.py
@@ -872,17 +872,15 @@ def recode_from_index_mapper(meta, series, index_mapper, append):
             ds[str(key)].loc[idx] = 1
         ds2 = condense_dichotomous_set(ds)
         series = join_delimited_set_series(series, ds2, append)
-        # Remove potential duplicate values
+        ## Remove potential duplicate values
         ds = series.str.get_dummies(';')
-        series = condense_dichotomous_set(ds[
-            [
-                str(c) 
-                for c in sorted(list(set([
-                    int(c) 
-                    for c in ds.columns
-                ])))
-            ]
-        ])
+        # Make sure columns are in numeric order
+        ds.columns = [int(float(c)) for c in ds.columns]
+        cols = sorted(ds.columns.tolist())
+        ds = ds[cols] 
+        ds.columns = [str(i) for i in ds.columns]
+        # Reconstruct the dichotomous set
+        series = condense_dichotomous_set(ds)
         
     elif qtype in ['single', 'int', 'float']:
         for key, idx in index_mapper.iteritems():


### PR DESCRIPTION
This resolves #129.

The cause was in single-to-delimited during the part that ensures de-duplication of the recode result, where some columns contained ``NaN``.