### PR TITLE
request_views() skip for nets/descriptives that cannot be found

### DIFF
--- a/core/tools/dp/query.py
+++ b/core/tools/dp/query.py
@@ -332,6 +332,10 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
                         net_cs[i].append(vt)
                         net_ps[i].append(vt)
                         net_cps[i].append(vt)
+    else:
+        net_cs = False
+        net_ps = False
+        net_cps = False
                 
     # Descriptive statistics views
     if descriptives:
@@ -377,6 +381,8 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
                             views[base_desc][i].extend(vrd)
         
         desc = views[base_desc]
+    else:
+        desc = False
 
     # Construct request object
     if by_x:
@@ -400,7 +406,7 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
     requested_views['grouped_views']['p'] = [bases, ps]
     requested_views['grouped_views']['cp'] = [bases, cps]
 
-    if nets:
+    if nets and net_cs and net_ps and net_cps:
         
         net_cs_flat = shake_nets([v for item in net_cs for v in item])
         net_ps_flat = shake_nets([v for item in net_ps for v in item])
@@ -426,7 +432,7 @@ def request_views(stack, weight=None, nets=True, descriptives=["mean"],
         requested_views['grouped_views']['p'].extend(net_ps)
         requested_views['grouped_views']['cp'].extend(net_cps)
         
-    if descriptives:
+    if descriptives and desc:
         
         desc_flat = shake_descriptives(
             [v for item in desc for v in item], 


### PR DESCRIPTION
Added skip for ``request_views()`` when nets or descriptives have been requested but cannot be found.