### PR TITLE
Supporting single-character column names

### DIFF
--- a/core/helpers/constants.py
+++ b/core/helpers/constants.py
@@ -15,4 +15,4 @@ DTYPE_MAP = {
     "grid": []
 }
 
-MAPPED_PATTERN = "^[^@].+[@].+[^@]$"
+MAPPED_PATTERN = "^[^@].*[@].*[^@]$"


### PR DESCRIPTION
Small change to the regular expression patter controlling the identification of meta-mapped string references.