### PR TITLE
Jupyter UnicodeDecodeError generating Open-end sheets in Excel

### DIFF
--- a/core/builds/excel/excel_painter.py
+++ b/core/builds/excel/excel_painter.py
@@ -10,6 +10,7 @@ import quantipy as qp
 from quantipy.core.cluster import Cluster
 from quantipy.core.chain import Chain
 from quantipy.core.helpers import functions as helpers
+from quantipy.core.tools.dp.io import unicoder
 from quantipy.core.builds.excel.formats.quantipy_basic import (
     STATIC_FORMATS
 )
@@ -913,6 +914,7 @@ def ExcelPainter(path_excel,
                         )
                     else:
                         series = series.fillna('__NA__')
+                        series = series.apply(unicoder)
                     
                     frames.append(series)
 

--- a/core/tools/dp/dimensions/reader.py
+++ b/core/tools/dp/dimensions/reader.py
@@ -779,7 +779,7 @@ def quantipy_from_dimensions(path_mdd, path_ddf, fields='all', grids=None):
 
     for key, col in meta['columns'].iteritems():
         if col['type']=='string':
-            ddf[key] = ddf[key].map(qp.core.tools.dp.io.unicoder)
+            ddf[key] = ddf[key].apply(qp.core.tools.dp.io.unicoder)
 
     return meta, ddf
 


### PR DESCRIPTION
Force-applying series.map(unicoder) to all string variables at both Dimensions conversion and ExcelPainter Open-ended sheet creation stages.