### PR TITLE
write_dimensions - date_format, CRLF and null strings

### DIFF
--- a/quantipy/core/tools/dp/dimensions/_create_ddf.dms
+++ b/quantipy/core/tools/dp/dimensions/_create_ddf.dms
@@ -37,7 +37,16 @@ Event(OnJobStart)
 	Set dmgrGlobal.CaseData = CreateObject("ADODB.Stream")
 
 	dmgrGlobal.CaseData.CharSet = "utf-8"
-	dmgrGlobal.CaseData.LineSeparator = adCR
+	Select Case CRLF
+		Case "CR"
+			dmgrGlobal.CaseData.LineSeparator = adCR
+		Case "CRLF"
+			dmgrGlobal.CaseData.LineSeparator = adCRLF
+		Case "LF"
+			dmgrGlobal.CaseData.LineSeparator = adLF
+		Case Else
+			Debug.Log("Unknown CRLF.")
+	End Select
 	dmgrGlobal.CaseData.Open()
 	dmgrGlobal.CaseData.LoadFromFile(MASTER_INPUT+"_datastore.csv")
 	
@@ -124,6 +133,7 @@ Event(OnNextCase)
 				End If
 			Case 2
 				oA = data[i].Replace(">_>_>", ",")
+				If oA = "" Then oA = NULL
 			Case 3
 				Select Case oA.Validation.MaxValue
 					Case 1

--- a/quantipy/core/tools/dp/dimensions/writer.py
+++ b/quantipy/core/tools/dp/dimensions/writer.py
@@ -298,18 +298,19 @@ def mask_to_mrs(meta, name, text_key):
 
     return mask_code, lang, ltype
 
-def create_ddf(master_input, path_dms, date_format):
+def create_ddf(master_input, path_dms, CRLF, date_format):
     dms_dummy_path = os.path.dirname(__file__)
     dms = open(os.path.join(dms_dummy_path, '_create_ddf.dms'), 'r')
     header = [
         '#define MASTER_INPUT "{}"'.format(master_input),
-        '#define DATE_FORMAT "{}"'.format(date_format)
+        '#define DATE_FORMAT "{}"'.format(date_format),
+        '#define CRLF "{}"'.format(CRLF),
     ]
     full_dms = header + [line.replace('\n', '') for line in dms]
     # NOTE:
     #-------------------------------------------------------------------------
     # dropping the second "line" which is an invisible line-break char
-    del full_dms[2]
+    del full_dms[3]
     with open(path_dms, 'w') as f:
         f.write('\n'.join(full_dms))
 
@@ -421,7 +422,7 @@ def convert_categorical(categorical):
     return cat
 
 def dimensions_from_quantipy(meta, data, path_mdd, path_ddf, text_key=None, 
-                             date_format='DMY', run=True, clean_up=True):
+                             CRLF="CR", date_format='DMY', run=True, clean_up=True):
     """
     DESCP
 
@@ -443,7 +444,7 @@ def dimensions_from_quantipy(meta, data, path_mdd, path_ddf, text_key=None,
 
     if not text_key: text_key = meta['lib']['default text']
     create_mdd(meta, data, path_mrs, path_mdd, text_key, run)
-    create_ddf(name, path_dms, date_format)
+    create_ddf(name, path_dms, CRLF, date_format)
     get_case_data_inputs(meta, data, path_paired_csv, path_datastore)
     print 'Case and meta data validated and transformed.'
     if run:

--- a/quantipy/core/tools/dp/io.py
+++ b/quantipy/core/tools/dp/io.py
@@ -297,7 +297,7 @@ def read_dimensions(path_mdd, path_ddf):
     return meta, data
 
 def write_dimensions(meta, data, path_mdd, path_ddf, text_key=None,
-                     date_format="DMY", run=True, clean_up=True):
+                     CRLF="CR", date_format="DMY", run=True, clean_up=True):
 
     default_stdout = sys.stdout
     default_stderr = sys.stderr
@@ -307,7 +307,7 @@ def write_dimensions(meta, data, path_mdd, path_ddf, text_key=None,
     sys.stderr = default_stderr
 
     out = dimensions_from_quantipy(meta, data, path_mdd, path_ddf,
-                                   text_key, run, clean_up)
+                                   text_key, CRLF, date_format, run, clean_up)
 
     default_stdout = sys.stdout
     default_stderr = sys.stderr


### PR DESCRIPTION
- Fix piping of date_format in write_dimensions
- Allow control over CRLF character in write_dimensions (CR=Windows, LF=Linux)
- Replace empty strings with Null in write_dimensions