### PR TITLE
bug in PptxChain.get_nets()

### DIFF
--- a/quantipy/sandbox/pptx/PptxChainClass.py
+++ b/quantipy/sandbox/pptx/PptxChainClass.py
@@ -228,7 +228,7 @@ class PptxDataFrame(pd.DataFrame):
         return pptx_df_copy
 
     def get_nets(self):
-        row_list = get_indexes_from_list(self.cell_contents, ['is_net','net'], exact=False)
+        row_list = get_indexes_from_list(self.cell_contents, ['net'], exact=False)
         dont_want = get_indexes_from_list(self.cell_contents, ['is_propstest'], exact=False)
 
         for x in dont_want:

--- a/quantipy/sandbox/pptx/PptxChainClass.py
+++ b/quantipy/sandbox/pptx/PptxChainClass.py
@@ -228,8 +228,8 @@ class PptxDataFrame(pd.DataFrame):
         return pptx_df_copy
 
     def get_nets(self):
-        row_list = get_indexes_from_list(self.cell_contents, ['net'], exact=False)
-        dont_want = get_indexes_from_list(self.cell_contents, ['is_propstest'], exact=False)
+        row_list = get_indexes_from_list(self.cell_contents, ['is_net', 'net'], exact=False)
+        dont_want = get_indexes_from_list(self.cell_contents, ['is_propstest','calc','normal'], exact=False)
 
         for x in dont_want:
             if x in row_list:
@@ -336,7 +336,7 @@ class PptxChain(object):
                       '\nGrid summary: {}'
                       '\nQuestion text: {}'
                       '\nBase description: {}'
-                      '\nBase label: {}'  
+                      '\nBase label: {}'
                       '\nBase size: {}'
                       '\nRequested crossbreak: {}'
                       '\n')


### PR DESCRIPTION
The method get_nets() in PptxChain used to extract net types from a Chains dataframe, ended up pulling other cell types as well. The method pulled both 'is_net' and 'net', only the latter should be pulled.
'is_net' can be other cell types included in a net.

