### PR TITLE
I1113 sorting on nets

### DIFF
--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -6239,7 +6239,8 @@ class DataSet(object):
             if on == '@' and is_array:
                 for source in self.sources(n):
                     self.sorting(source, fix=fix, within=within,
-                                 between=between, ascending=ascending)
+                                 between=between, ascending=ascending,
+                                 sort_by_weight=sort_by_weight)
             else:
                 if 'rules' not in self._meta[collection][n]:
                     self._meta[collection][n]['rules'] = {'x': {}, 'y': {}}
@@ -6247,13 +6248,13 @@ class DataSet(object):
                     n_fix = self._clean_codes_against_meta(n, fix)
                 else:
                     n_fix = self._clean_items_against_meta(n, fix)
-                rule_update = {'sortx': {'ascending': ascending,
-                                         'within': within,
-                                         'between': between,
-                                         'fixed': n_fix,
-                                         'sort_on': on,
-                                         'with_weight': sort_by_weight}}
-                self._meta[collection][n]['rules']['x'].update(rule_update)
+                rule_update = {'ascending': ascending,
+                               'within': within,
+                               'between': between,
+                               'fixed': n_fix,
+                               'sort_on': on,
+                               'with_weight': sort_by_weight}
+                self._meta[collection][n]['rules']['x']['sortx'] = rule_update
         return None
 
     def _clean_missing_map(self, var, missing_map):

--- a/quantipy/core/rules.py
+++ b/quantipy/core/rules.py
@@ -303,7 +303,7 @@ class Rules(object):
         within = sortx.get('within', True)
         between = sortx.get('between', True)
         ascending = sortx.get('ascending', False)
-        fix = sortx.get('fix', None)
+        fix = sortx.get('fixed', None)
         if not within and not between: return view.dataframe
         df = view.dataframe
         name = df.index.levels[0][0]
@@ -344,7 +344,8 @@ class Rules(object):
             is_code = len(g) == 1
             if not is_code:
                 fixed_net_name = g[0]
-                sort = [(name, v) for v in g[1:]]
+                fixed_in_g = [v for v in g[1:] if v in fix_codes]
+                sort = [(name, v) for v in g[1:] if not v in fixed_in_g]
                 if within:
                     if pd.__version__ == '0.19.2':
                         temp_df = df.loc[sort].sort_values(sort_col, 0, ascending=ascending)
@@ -352,8 +353,9 @@ class Rules(object):
                         temp_df = df.loc[sort].sort_index(0, sort_col, ascending=ascending)
                 else:
                     temp_df = df.loc[sort]
-                new_idx = [fixed_net_name] + temp_df.index.get_level_values(1).tolist()
+                new_idx = [fixed_net_name] + temp_df.index.get_level_values(1).tolist() + fixed_in_g
                 final_index.extend(new_idx)
+                fix_codes = [c for c in fix_codes if not c in fixed_in_g]
             else:
                 final_index.extend(g)
         # build final index including any fixed codes

--- a/quantipy/core/rules.py
+++ b/quantipy/core/rules.py
@@ -263,11 +263,11 @@ class Rules(object):
             ('sortx', self.sortx),
             ('dropx', self.dropx)])
 
+        if not apply_rules: apply_rules = rulesx.keys()
         for r, method in rulesx.items():
             if apply_rules and r in apply_rules:
                 if r in rules:
                     f = method(f, **rules[r])
-
         rules_slicer = f.index.values.tolist()
         col_key = f.index.levels[0].tolist()[0]
         if (col_key, 'All') in rules_slicer:

--- a/quantipy/core/rules.py
+++ b/quantipy/core/rules.py
@@ -436,7 +436,8 @@ class Rules(object):
             if fixed is None:
                 s_fixed = []
             else:
-                s_fixed = [(name_x, value) for value in fixed]
+                s_fixed = [(name_x, value) for value in fixed
+                           if (name_x, value) in s_sort]
                 # Drop fixed tuples from the sort slicer
                 s_sort = [t for t in s_sort if not t in s_fixed]
 

--- a/quantipy/core/rules.py
+++ b/quantipy/core/rules.py
@@ -94,6 +94,11 @@ class Rules(object):
                 net_weights = [k.split('|')[-2] for k in self.link.keys()
                                if k.split('|')[-1] == 'net']
                 if not sort_weight in net_weights: sort_weight = net_weights[0]
+            elif sort_on == '@':
+                expanded_nets_w = [k.split('|')[-2] for k in self.link.keys()
+                                   if '}+]' in k.split('|')[2]]
+                if expanded_nets_w and not sort_weight in expanded_nets_w:
+                    sort_weight = expanded_nets_w[0]
             return sort_weight
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
"rewrite" of Rules module (affecting 90% sorting + get proper rules-slicer even for inconsistent link_weight):

sorting "normal" columns:
* `sort_on` always '@'
* `fix` any categories
* `sort_by_weight` default is unweighted (None), but each weight (included in data) can be used

sorting "expanded net" columns:
* `sort_on` always '@'
* `fix` any categories
* sorting `within` or `between` net groups is available
* `sort_by_weight`: as default the weight of the first found expanded-net-view is taken. Only weights of aggregated net-views are possible

sorting "array summaries":
* `sort_on` can be any desc ('median', 'stddev', 'sem', 'max', 'min',  'mean', 'upper_q', 'lower_q') or nets ('net_1', 'net_2', .... enumerated by the net_def)
* `sort_by_weight`: as default the weight of the first found desc/net-view is taken. Only weights of aggregated desc/net-views are possible
* `sort_on` can also be any category, here each weight can be used to `sort_on`