### PR TITLE
add method add_chain() to ChainManager

### DIFF
--- a/quantipy/sandbox/sandbox.py
+++ b/quantipy/sandbox/sandbox.py
@@ -105,6 +105,9 @@ class ChainManager(object):
             raise StopIteration
     next = __next__
 
+    def add_chain(self, chain):
+        self.__chains.append(chain)
+
     @property
     def folders(self):
         """


### PR DESCRIPTION
Interim fix for adding a chain to a chainmanager to support Brandhouse