### PR TITLE
dataset.meta_to_json() string join error

### DIFF
--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -800,7 +800,7 @@ class DataSet(object):
             name = '{}{}'.format(collection, '_{}'.format(key.split('.')[0])
                                  if key else '')
         ds_path = '../' if self.path == '/' else self.path
-        path = os.path.join(ds_path, ''.json([self.name, '_', name, '.json']))
+        path = os.path.join(ds_path, ''.join([self.name, '_', name, '.json']))
         with open(path, 'w') as file:
             json.dump(obj, file)
         print u'create: {}'.format(path)


### PR DESCRIPTION
I found this error while using `dataset.meta_to_json()` and submit this fix
```
~/quantipy/quantipy/core/dataset.pyc in meta_to_json(self, key, collection)
    801                                  if key else '')
    802         ds_path = '../' if self.path == '/' else self.path
--> 803         path = os.path.join(ds_path, ''.json([self.name, '_', name, '.json']))
    804         with open(path, 'w') as file:
    805             json.dump(obj, file)

AttributeError: 'str' object has no attribute 'json'

In [11]: dataset.meta_to_json()
```