### PR TITLE
Techops 548 add decorative

### DIFF
--- a/quantipy/sandbox/excel.py
+++ b/quantipy/sandbox/excel.py
@@ -56,6 +56,7 @@ _SHEET_DEFAULTS = dict(alternate_bg             = True,
                        img_size                 = [130, 130],
                        img_x_offset             = 0,
                        img_y_offset             = 0,
+                       decorative               = False,
                        row_height_label         = 12.75,
                        start_column             = 0,
                        start_row                = 0,
@@ -661,6 +662,7 @@ class _Sheet(Worksheet):
                 self.image.get('img_insert_y', self.img_insert_y),
                 self.image['img_name'],
                 dict(
+                    decorative=self.image.get('decorative', self.decorative),
                     x_offset=self.image.get('img_x_offset', self.img_x_offset),
                     y_offset=self.image.get('img_y_offset', self.img_y_offset))
             )


### PR DESCRIPTION
Decorative option added to excel.insert_image() method.
The decorative parameter is used to mark the image as decorative, and thus uninformative, for automated screen readers.
It requires an upgrade for xlsxwriter from 1.1.9 to 1.3.8 where the decorative option was added.