### PR TITLE
Techops 811

### DIFF
--- a/quantipy/core/tools/view/logic.py
+++ b/quantipy/core/tools/view/logic.py
@@ -31,7 +31,7 @@ def verify_logic_values(values, func_name):
     """
     if isinstance(values, (list, tuple)):
         for value in values:
-            if not isinstance(value, int):
+            if not isinstance(value, (int, long)):
                 raise TypeError(
                     "The values given to %s() are not correctly "
                     "typed. Expected list of <int>, found a %s." % (

--- a/quantipy/core/tools/view/logic.py
+++ b/quantipy/core/tools/view/logic.py
@@ -33,8 +33,8 @@ def verify_logic_values(values, func_name):
         for value in values:
             if not isinstance(value, (int, long)):
                 raise TypeError(
-                    "The values given to %s() are not correctly "
-                    "typed. Expected list of <int>, found a %s." % (
+                    "The values given to %s() are not correctly typed. "
+                    "Expected list of 'int' or 'long', found a %s." % (
                         func_name,
                         type(value)
                     )


### PR DESCRIPTION
The verify_logic_values method need to be updated to include long type values as well as int:

-from:

 if not isinstance(value, int):

-to:

 if not isinstance(value, (int, long)):

This is done to accomodate changes needed due to the move to bigint.