### PR TITLE
Techops 838 caseid

### DIFF
--- a/quantipy/core/tools/dp/dimensions/writer.py
+++ b/quantipy/core/tools/dp/dimensions/writer.py
@@ -223,6 +223,7 @@ def col_to_mrs(meta, data, col, text_key):
     if column['type'] == 'int':
         if data[col].max() > MaxIntValue or data[col].min() < MinIntValue:
             dimtype = 'mr.Double'
+    if name == 'caseid': dimtype = 'mr.Double'
     col_code = [
         section_break(20),
         comment(0, '{}'.format(name)),


### PR DESCRIPTION
Force caseid to mr.Double as caseid meta needs to be consistent regardless of the data values.